### PR TITLE
[DT-046035] Adding Slack module as project dependency throws method not found error 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.ps1.error
 .vs/*
 Module.Modified.xml
+Decisions.Slack.TestSuite/**
 
 # Build results
 **/[Dd]ebug/

--- a/Decisions.Slack/Decisions.Slack.csproj
+++ b/Decisions.Slack/Decisions.Slack.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="DecisionsSDK" Version="9.15.0" />
+      <PackageReference Include="DecisionsSDK" Version="9.17.0-beta" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="SlackNet" Version="0.17.4" />
         <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />


### PR DESCRIPTION
There were framework changes in 9.17 that affected modules.